### PR TITLE
Update transaction.js

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -95,7 +95,7 @@ class Transaction {
                 return; // buffering for banners
             }
 
-            new_line = new_line.replace(/^\./gm, '..').replace(/\r?\n/gm, '\r\n');
+            new_line = new_line.toString('binary').replace(/^\./gm, '..').replace(/\r?\n/gm, '\r\n');
             line = new Buffer(new_line,'binary');
         }
 


### PR DESCRIPTION
Add Buffer to string conversion to prevent TypeError.

```
    TypeError: new_line.replace is not a function
      at Transaction.add_data (node_modules/haraka-test-fixtures/lib/transaction.js:98:33)
      at Context.<anonymous> (test/test.js:1470:41)
      at process.processImmediate (node:internal/timers:476:21)

```