### PR TITLE
Release v1.3.2

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 ### Unreleased
 
 
+### [1.3.2] - 2023-12-12
+
+- dep(haraka-results): bump version to 2.2.3
+
+
 ### [1.3.1] - 2023-12-03
 
 - transaction: update Buffer syntax (sync with Haraka) (#56)
@@ -187,3 +192,4 @@
 [1.2.1]: https://github.com/haraka/test-fixtures/releases/tag/1.2.1
 [1.3.0]: https://github.com/haraka/test-fixtures/releases/tag/1.3.0
 [1.4.0]: https://github.com/haraka/test-fixtures/releases/tag/1.4.0
+[1.3.2]: https://github.com/haraka/test-fixtures/releases/tag/1.3.2

--- a/Changes.md
+++ b/Changes.md
@@ -191,5 +191,5 @@
 [1.2.0]: https://github.com/haraka/test-fixtures/releases/tag/1.2.0
 [1.2.1]: https://github.com/haraka/test-fixtures/releases/tag/1.2.1
 [1.3.0]: https://github.com/haraka/test-fixtures/releases/tag/1.3.0
-[1.4.0]: https://github.com/haraka/test-fixtures/releases/tag/1.4.0
+[1.3.1]: https://github.com/haraka/test-fixtures/releases/tag/1.3.1
 [1.3.2]: https://github.com/haraka/test-fixtures/releases/tag/1.3.2

--- a/Changes.md
+++ b/Changes.md
@@ -187,9 +187,9 @@
 
 
 [1.0.35]: https://github.com/haraka/haraka-test-fixtures/releases/tag/1.0.35
-[1.1.0]: https://github.com/haraka/haraka-test-fixtures/releases/tag/1.1.0
-[1.2.0]: https://github.com/haraka/test-fixtures/releases/tag/1.2.0
-[1.2.1]: https://github.com/haraka/test-fixtures/releases/tag/1.2.1
-[1.3.0]: https://github.com/haraka/test-fixtures/releases/tag/1.3.0
-[1.3.1]: https://github.com/haraka/test-fixtures/releases/tag/1.3.1
-[1.3.2]: https://github.com/haraka/test-fixtures/releases/tag/1.3.2
+[1.1.0]: https://github.com/haraka/haraka-test-fixtures/releases/tag/v1.1.0
+[1.2.0]: https://github.com/haraka/test-fixtures/releases/tag/v1.2.0
+[1.2.1]: https://github.com/haraka/test-fixtures/releases/tag/v1.2.1
+[1.3.0]: https://github.com/haraka/test-fixtures/releases/tag/v1.3.0
+[1.3.1]: https://github.com/haraka/test-fixtures/releases/tag/v1.3.1
+[1.3.2]: https://github.com/haraka/test-fixtures/releases/tag/v1.3.2

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "haraka-test-fixtures",
   "license": "MIT",
   "description": "Haraka Test Fixtures",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "repository": {
     "type": "git",
     "url": "git@github.com:haraka/test-fixtures.git"
@@ -18,12 +18,12 @@
     "haraka-constants": "*",
     "haraka-email-message": "~1.2",
     "haraka-notes": "*",
-    "haraka-results": "^2.2.0"
+    "haraka-results": "^2.2.3"
   },
   "devDependencies": {
-    "eslint": "^8.0.0",
+    "eslint": "^8.55.0",
     "eslint-plugin-haraka": "*",
-    "mocha": "^9.0.0"
+    "mocha": "^10.2.0"
   },
   "bugs": {
     "url": "https://github.com/haraka/test-fixtures/issues"


### PR DESCRIPTION
- dep(haraka-results): bump version to 2.2.3
- doc(changes): fix release URLs