### PR TITLE
Release v1.3.3

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 ### Unreleased
 
 
+### [1.3.3] - 2023-12-12
+
+- deps(\*): pin versions to latest
+
+
 ### [1.3.2] - 2023-12-12
 
 - dep(haraka-results): bump version to 2.2.3
@@ -193,3 +198,4 @@
 [1.3.0]: https://github.com/haraka/test-fixtures/releases/tag/v1.3.0
 [1.3.1]: https://github.com/haraka/test-fixtures/releases/tag/v1.3.1
 [1.3.2]: https://github.com/haraka/test-fixtures/releases/tag/v1.3.2
+[1.3.3]: https://github.com/haraka/test-fixtures/releases/tag/1.3.3

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "node": ">=12"
   },
   "dependencies": {
-    "address-rfc2821": "*",
-    "haraka-config": "*",
-    "haraka-constants": "*",
-    "haraka-email-message": "~1.2",
-    "haraka-notes": "*",
+    "address-rfc2821": "2.1.1",
+    "haraka-config": "^1.1.0",
+    "haraka-constants": "1.0.6",
+    "haraka-email-message": "~1.2.0",
+    "haraka-notes": "1.0.6",
     "haraka-results": "^2.2.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "haraka-test-fixtures",
   "license": "MIT",
   "description": "Haraka Test Fixtures",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "repository": {
     "type": "git",
     "url": "git@github.com:haraka/test-fixtures.git"


### PR DESCRIPTION
- deps(*): pin versions to latest, because this module is depended on by so many others, and npm resolution doesn't seems to pick the most recent versions with `*` is specified.