### PR TITLE
vm_harness: access local files in plugin directory

### DIFF
--- a/lib/vm_harness.js
+++ b/lib/vm_harness.js
@@ -5,6 +5,7 @@ const vm = require('vm')
 const dir_paths = [
   `${__dirname}/../../../`, // for Haraka/tests/plugins
   `${__dirname}/`, // for haraka-test-fixtures/test
+  `${__dirname}/../../../../../`, // for files in Haraka/
 ]
 
 function dot_files(element) {
@@ -12,6 +13,11 @@ function dot_files(element) {
 }
 
 function find_haraka_lib(id) {
+  // For local files in the project root directory
+  // e.g. "require('./example.js')"
+  if (id.includes('./') && id.includes('.js')) {
+    id = id.substring(2, (id.length - 3))
+  }
   for (let i = 0; i < dir_paths.length; i++) {
     const dirPath = `${dir_paths[i]}${id}.js`
     // console.log('dirPath: ' + dirPath);


### PR DESCRIPTION
Adds ability for vm_harness find_haraka_lib(id) to load a local .js file that is stored in the plugin directory (passed as parameter 'id'). 

Intended to address issue https://github.com/haraka/test-fixtures/issues/45