### PR TITLE
logger: only check for PROTOCOL once

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -18,9 +18,9 @@ logger.levels = {
 logger.log = function (level, data) {
   if (level === 'PROTOCOL') {
     data = data.replace(/\n/g, '\\n\n')
+    return
   }
   if (level === 'DEBUG') return
-  if (level === 'PROTOCOL') return
   data = data.replace(/\r/g, '\\r').replace(/\n$/, '')
 
   console.log(data)


### PR DESCRIPTION
It is inefficient to check for PROTOCOL twice.